### PR TITLE
devops: StudyLens on ECS Fargate + EFS + ALB + CloudFront (keyless Bedrock)

### DIFF
--- a/devops/studylens-fargate-bedrock/.gitignore
+++ b/devops/studylens-fargate-bedrock/.gitignore
@@ -1,0 +1,7 @@
+# Terraform
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/*.tfstate
+terraform/*.tfstate.*
+terraform/terraform.tfvars
+crash.log

--- a/devops/studylens-fargate-bedrock/README.md
+++ b/devops/studylens-fargate-bedrock/README.md
@@ -1,0 +1,116 @@
+# StudyLens on ECS Fargate + EFS + ALB + CloudFront (keyless Bedrock)
+
+Deploy a stateful single-container Node app ([`studylens`](https://www.npmjs.com/package/studylens))
+to AWS as a **fully-managed (免运维), low-cost, phone/iPad-friendly** service with:
+
+- **Persistent storage** on EFS (StudyLens keeps its knowledge base as JSON files on the local FS — no DB),
+- **A trusted HTTPS URL with no domain / no ACM cert** (CloudFront's free `*.cloudfront.net` cert),
+- **Keyless LLM access**: an in-container adapter translates the app's OpenAI-compatible calls to
+  **Amazon Bedrock Converse** (`us.openai.gpt-5.6-luna`) using the ECS **task IAM role** — no API key stored anywhere,
+- **HTTP Basic-Auth** in front (the app ships no auth of its own).
+
+This directory is a reusable pattern; it happens to wrap StudyLens but applies to any stateful,
+local-filesystem, OpenAI-compatible container.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  U[iPhone / iPad] -->|HTTPS| CF[CloudFront<br/>free *.cloudfront.net cert<br/>redirect-to-https]
+  CF -->|HTTP origin fetch| ALB[Application Load Balancer<br/>internet-facing :80]
+  ALB --> TG[Target Group<br/>ip / :3000 / health 200,401]
+  TG --> T[ECS Fargate task<br/>0.25 vCPU / 0.5 GB]
+  subgraph Task
+    W[Basic-Auth wrapper :3000] --> APP[StudyLens Express app]
+    APP -->|/data| EFS[(EFS access point<br/>persistent knowledge base)]
+    W -. localhost:8787 .-> AD[Bedrock adapter]
+  end
+  AD -->|Converse SigV4 via task role| BR[Amazon Bedrock<br/>us.openai.gpt-5.6-luna]
+```
+
+Why these choices:
+
+- **ECS Fargate, not App Runner.** App Runner **cannot mount EFS**
+  ([apprunner-roadmap #14](https://github.com/aws/apprunner-roadmap/issues/14)) and stops accepting new
+  customers 2026-04-30. A local-filesystem app on App Runner loses all data on every restart. Fargate mounts EFS natively.
+- **CloudFront for HTTPS.** With no registered domain, an ALB alone only yields untrusted
+  `http://*.elb.amazonaws.com` — Basic-Auth over plain HTTP would leak the password. Every CloudFront
+  distribution gets a free trusted cert, so `https://xxxx.cloudfront.net` works on iOS and "Add to Home Screen".
+- **Keyless Bedrock adapter.** StudyLens only speaks OpenAI `/v1/chat/completions`. `app/bedrock-openai-adapter.js`
+  exposes that shape on `localhost:8787` and forwards to Bedrock `Converse` via the task role. `openai.gpt-5.6-luna`
+  requires an **inference profile** (`us.openai.gpt-5.6-luna`) — the bare model id is rejected for on-demand.
+
+## Files
+
+| Path | What it is |
+|---|---|
+| `app/Dockerfile` | `node:20-slim` wrapping `studylens@0.1.8` (portal SPA is prebuilt in the tarball) + the AWS SDK for the adapter |
+| `app/server.js` | HTTP Basic-Auth gate composed in front of the StudyLens Express app |
+| `app/bedrock-openai-adapter.js` | OpenAI `/v1/chat/completions` → Bedrock `Converse` shim (SigV4/IAM, no key) |
+| `app/entrypoint.sh` | Ensures `/data` dirs, seeds `llm-config.json` on first boot only, starts adapter then app |
+| `app/buildspec.yml` | CodeBuild spec: ECR login → `docker build` → push `:latest` |
+| `terraform/` | Full IaC reproducing the live stack (EFS, IAM, ECS, ALB, CloudFront) |
+
+## Deploy — build the image (CodeBuild, no local Docker needed)
+
+The gateway host had no Docker access, so the image is built by CodeBuild.
+
+```bash
+# 1. ECR repo
+aws ecr create-repository --repository-name studylens --region us-east-1
+
+# 2. Zip app/ (Dockerfile + server.js + bedrock-openai-adapter.js + entrypoint.sh + buildspec.yml)
+#    and upload to an S3 bucket the CodeBuild role can read.
+zip -j source.zip app/*
+aws s3 cp source.zip s3://<your-bucket>/studylens-build/source.zip
+
+# 3. A CodeBuild project (privileged Linux, amazonlinux2-x86_64-standard:5.0) with env ECR_URI,
+#    service role allowing ecr:* on the repo + logs + s3:GetObject on the source, then:
+aws codebuild start-build --project-name studylens-build
+# -> pushes <acct>.dkr.ecr.us-east-1.amazonaws.com/studylens:latest
+```
+
+## Deploy — infrastructure (Terraform)
+
+```bash
+cd terraform
+cp terraform.tfvars.example terraform.tfvars   # fill image_uri; keep the password out of git
+export TF_VAR_basic_auth_pass='<your-password>'
+
+terraform init
+terraform apply
+terraform output public_url    # https://xxxx.cloudfront.net  (add to Home Screen)
+```
+
+The Terraform module creates: EFS filesystem + access point (uid/gid 1000, `/studylens`) + one mount
+target per supported AZ; task SG (NFS self + 3000 from ALB) and ALB SG (80 in); the task execution role
+(`AmazonECSTaskExecutionRolePolicy`) and task role (Bedrock `InvokeModel`/`Converse`); a CloudWatch log
+group; the ECS cluster, task definition (EFS volume at `/data`), and service (1 task, public IP); the ALB
++ target group + HTTP listener; and the CloudFront distribution with the managed *CachingDisabled* +
+*AllViewerExceptHostHeader* policies.
+
+> **AZ note (this account):** ECS/ALB reject `use1-az3/az5/az6`. `supported_azs` defaults to
+> `us-east-1a/1c/1d`; adjust for other accounts.
+
+> **ECS prerequisite:** the account needs the service-linked role `AWSServiceRoleForECS`
+> (`aws iam create-service-linked-role --aws-service-name ecs.amazonaws.com`) once per account.
+
+## Operations
+
+- **Redeploy after an image push:** `aws ecs update-service --cluster studylens --service studylens --force-new-deployment`
+- **Logs:** CloudWatch group `/ecs/studylens`
+- **Health:** ALB target group health check on `/` accepts `200,401` (401 = the Basic-Auth gate is up)
+- **Change the LLM in the UI:** StudyLens rewrites `/data/llm-config.json`; `entrypoint.sh` only seeds it on
+  first boot, so UI edits survive redeploys.
+
+## Cost (~$22/mo, us-east-1)
+
+ALB ~$16 + Fargate 0.25 vCPU / 0.5 GB always-on ~$6 + EFS/CloudFront pennies + Bedrock per-token (pay-per-use).
+The ALB is the bulk; to reach ~$6–12/mo you would move off Fargate to a single always-on EC2 + Elastic IP
+(trading zero-ops for OS patching), since CloudFront needs a stable resolvable origin and a Fargate task's
+public IP is ephemeral.
+
+## Teardown
+
+`terraform destroy` (from `terraform/`) removes everything this module created. If you built via CodeBuild,
+also delete the ECR repo, the CodeBuild project, the S3 source object, and the `/ecs/studylens` log group.

--- a/devops/studylens-fargate-bedrock/app/Dockerfile
+++ b/devops/studylens-fargate-bedrock/app/Dockerfile
@@ -1,0 +1,37 @@
+# StudyLens on AWS App Runner — small Node image wrapping the published npm tarball.
+# The published tarball already ships portal/dist (prebuilt SPA), so no front-end
+# build is needed here; we only install the server's runtime deps.
+FROM node:20-slim
+
+WORKDIR /app
+
+# Install studylens from npm at a pinned version, production deps only.
+# --ignore-scripts skips the package's postinstall (cd portal && npm install),
+# which is unnecessary because portal/dist is already built and shipped.
+# The AWS SDK v3 Bedrock client is added for the OpenAI->Bedrock adapter.
+RUN npm install --omit=dev --ignore-scripts \
+      studylens@0.1.8 \
+      @aws-sdk/client-bedrock-runtime@^3 \
+    && npm cache clean --force
+
+# Basic-Auth front door, Bedrock adapter, and config-seeding wrapper.
+COPY server.js /app/server.js
+COPY bedrock-openai-adapter.js /app/bedrock-openai-adapter.js
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# App Runner routes to this port; StudyLens listens on $PORT (default 3000).
+ENV PORT=3000
+# OpenAI->Bedrock adapter (localhost only).
+ENV ADAPTER_PORT=8787
+ENV BEDROCK_REGION=us-east-1
+ENV BEDROCK_MODEL_ID=us.openai.gpt-5.6-luna
+# Data lives on the mounted EFS volume (see App Runner service config).
+ENV STUDYLENS_DATA_DIR=/data
+ENV STUDYLENS_WIKI_DIR=/data/wiki
+ENV STUDYLENS_CONFIG_DIR=/data
+ENV STUDYLENS_UPLOAD_DIR=/data/uploads
+ENV STUDYLENS_LOG_DIR=/data/logs
+
+EXPOSE 3000
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/devops/studylens-fargate-bedrock/app/bedrock-openai-adapter.js
+++ b/devops/studylens-fargate-bedrock/app/bedrock-openai-adapter.js
@@ -1,0 +1,135 @@
+// Bedrock <- OpenAI adapter.
+//
+// StudyLens only speaks the OpenAI Chat Completions wire format
+// (POST {baseUrl}/chat/completions, Bearer auth). Amazon Bedrock uses a
+// different API (Converse) with SigV4/IAM auth. This tiny server bridges the
+// two: it listens on localhost inside the container, accepts OpenAI-shaped
+// chat-completion requests, and forwards them to Bedrock's Converse API using
+// the App Runner instance role (no API key anywhere).
+//
+// StudyLens is pointed at  http://localhost:8787/v1  as an "openai-compatible"
+// provider with an empty apiKey; this process does the real call to
+// modelId = BEDROCK_MODEL_ID (an inference profile, e.g. us.openai.gpt-5.6-luna).
+const http = require('http');
+const {
+  BedrockRuntimeClient,
+  ConverseCommand,
+} = require('@aws-sdk/client-bedrock-runtime');
+
+const PORT = parseInt(process.env.ADAPTER_PORT || '8787', 10);
+const REGION = process.env.BEDROCK_REGION || 'us-east-1';
+// Must be an inference profile id for on-demand GPT-5.6 Luna.
+const MODEL_ID = process.env.BEDROCK_MODEL_ID || 'us.openai.gpt-5.6-luna';
+
+const client = new BedrockRuntimeClient({ region: REGION });
+
+// Convert OpenAI chat messages -> Bedrock Converse (messages[] + optional
+// system[]). Bedrock pulls the system prompt into a separate `system` field.
+function toBedrock(openaiMessages) {
+  const system = [];
+  const messages = [];
+  for (const m of openaiMessages || []) {
+    const text = typeof m.content === 'string'
+      ? m.content
+      : Array.isArray(m.content)
+        ? m.content.map((c) => (typeof c === 'string' ? c : c.text || '')).join('')
+        : String(m.content ?? '');
+    if (m.role === 'system') {
+      system.push({ text });
+    } else if (m.role === 'assistant') {
+      messages.push({ role: 'assistant', content: [{ text }] });
+    } else {
+      // user + any unknown role fold into a user turn
+      messages.push({ role: 'user', content: [{ text }] });
+    }
+  }
+  return { system, messages };
+}
+
+// Bedrock rejects consecutive same-role turns; merge them defensively, and
+// require the first message to be a user turn.
+function coalesce(messages) {
+  const out = [];
+  for (const msg of messages) {
+    const last = out[out.length - 1];
+    if (last && last.role === msg.role) {
+      last.content.push(...msg.content);
+    } else {
+      out.push({ role: msg.role, content: [...msg.content] });
+    }
+  }
+  while (out.length && out[0].role !== 'user') out.shift();
+  return out;
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (c) => { data += c; if (data.length > 25 * 1024 * 1024) req.destroy(); });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET' && req.url === '/healthz') {
+    res.writeHead(200, { 'Content-Type': 'text/plain' });
+    return res.end('ok');
+  }
+  // Accept both /v1/chat/completions and /chat/completions.
+  if (req.method === 'POST' && /\/chat\/completions$/.test(req.url)) {
+    try {
+      const raw = await readBody(req);
+      const payload = JSON.parse(raw || '{}');
+      const { system, messages } = toBedrock(payload.messages);
+      const coalesced = coalesce(messages);
+
+      const inferenceConfig = {};
+      if (payload.max_tokens != null) inferenceConfig.maxTokens = payload.max_tokens;
+      if (payload.temperature != null) inferenceConfig.temperature = payload.temperature;
+      if (payload.top_p != null) inferenceConfig.topP = payload.top_p;
+      if (inferenceConfig.maxTokens == null) inferenceConfig.maxTokens = 4096;
+
+      const cmd = new ConverseCommand({
+        modelId: MODEL_ID,
+        messages: coalesced,
+        ...(system.length ? { system } : {}),
+        inferenceConfig,
+      });
+      const out = await client.send(cmd);
+      const text = (out.output?.message?.content || [])
+        .map((c) => c.text || '')
+        .join('');
+
+      // Shape the reply as an OpenAI chat.completion so StudyLens's parser
+      // (data.choices[0].message.content) works unchanged.
+      const body = JSON.stringify({
+        id: 'chatcmpl-bedrock',
+        object: 'chat.completion',
+        created: Math.floor(Date.now() / 1000),
+        model: MODEL_ID,
+        choices: [{
+          index: 0,
+          message: { role: 'assistant', content: text },
+          finish_reason: out.stopReason === 'max_tokens' ? 'length' : 'stop',
+        }],
+        usage: {
+          prompt_tokens: out.usage?.inputTokens ?? 0,
+          completion_tokens: out.usage?.outputTokens ?? 0,
+          total_tokens: out.usage?.totalTokens ?? 0,
+        },
+      });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      return res.end(body);
+    } catch (err) {
+      res.writeHead(502, { 'Content-Type': 'application/json' });
+      return res.end(JSON.stringify({ error: { message: String(err && err.message || err) } }));
+    }
+  }
+  res.writeHead(404, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ error: { message: 'not found' } }));
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Bedrock adapter on http://127.0.0.1:${PORT} -> ${MODEL_ID} (${REGION})`);
+});

--- a/devops/studylens-fargate-bedrock/app/bedrock-openai-adapter.js
+++ b/devops/studylens-fargate-bedrock/app/bedrock-openai-adapter.js
@@ -122,8 +122,9 @@ const server = http.createServer(async (req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       return res.end(body);
     } catch (err) {
+      console.error('bedrock-openai-adapter request failed:', err);
       res.writeHead(502, { 'Content-Type': 'application/json' });
-      return res.end(JSON.stringify({ error: { message: String(err && err.message || err) } }));
+      return res.end(JSON.stringify({ error: { message: 'Upstream request failed' } }));
     }
   }
   res.writeHead(404, { 'Content-Type': 'application/json' });

--- a/devops/studylens-fargate-bedrock/app/buildspec.yml
+++ b/devops/studylens-fargate-bedrock/app/buildspec.yml
@@ -1,0 +1,17 @@
+version: 0.2
+phases:
+  pre_build:
+    commands:
+      - echo "Logging in to ECR $ECR_URI"
+      - REGION=${AWS_DEFAULT_REGION:-us-east-1}
+      - ACCOUNT=$(echo "$ECR_URI" | cut -d. -f1)
+      - aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "${ACCOUNT}.dkr.ecr.${REGION}.amazonaws.com"
+  build:
+    commands:
+      - echo "Building image"
+      - docker build -t "$ECR_URI:latest" .
+  post_build:
+    commands:
+      - echo "Pushing image"
+      - docker push "$ECR_URI:latest"
+      - echo "Done -> $ECR_URI:latest"

--- a/devops/studylens-fargate-bedrock/app/entrypoint.sh
+++ b/devops/studylens-fargate-bedrock/app/entrypoint.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+set -e
+
+# EFS is mounted at /data. Ensure the data subdirs exist.
+mkdir -p /data/wiki /data/uploads /data/logs
+
+CONFIG_FILE="${STUDYLENS_CONFIG_DIR:-/data}/llm-config.json"
+
+# Seed the LLM config ONLY if it does not already exist, so edits made in the
+# StudyLens UI (which rewrites this same file) survive redeploys. The provider
+# is "openai-compatible" pointed at the local Bedrock adapter, apiKey empty
+# (the adapter authenticates to Bedrock with the instance IAM role).
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Seeding LLM config -> $CONFIG_FILE"
+  cat > "$CONFIG_FILE" <<JSON
+{
+  "defaultProvider": "openai-compatible",
+  "providers": {
+    "openai-compatible": {
+      "enabled": true,
+      "baseUrl": "http://127.0.0.1:${ADAPTER_PORT:-8787}/v1",
+      "apiKey": "",
+      "model": "${BEDROCK_MODEL_ID:-us.openai.gpt-5.6-luna}"
+    }
+  },
+  "taskRouting": {
+    "analyze": "default",
+    "questions": "default",
+    "topicPage": "default",
+    "qa": "default",
+    "expand": "default"
+  }
+}
+JSON
+else
+  echo "LLM config already present at $CONFIG_FILE — leaving as-is."
+fi
+
+# Start the Bedrock adapter in the background.
+node /app/bedrock-openai-adapter.js &
+ADAPTER_PID=$!
+
+# Wait for the adapter to be healthy (max ~15s), so the first StudyLens call
+# doesn't race a not-yet-listening adapter.
+i=0
+while [ $i -lt 30 ]; do
+  if node -e "require('http').get('http://127.0.0.1:'+(process.env.ADAPTER_PORT||8787)+'/healthz',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))" 2>/dev/null; then
+    echo "Adapter healthy."
+    break
+  fi
+  i=$((i+1))
+  sleep 0.5
+done
+
+# If the adapter died, fail the container (App Runner will restart it).
+if ! kill -0 "$ADAPTER_PID" 2>/dev/null; then
+  echo "Adapter process exited during startup — aborting."
+  exit 1
+fi
+
+# Launch the auth-gated StudyLens server in the foreground (PID 1 role).
+exec node /app/server.js

--- a/devops/studylens-fargate-bedrock/app/server.js
+++ b/devops/studylens-fargate-bedrock/app/server.js
@@ -1,0 +1,47 @@
+// Basic-Auth front door for StudyLens.
+//
+// StudyLens ships no authentication, and the App Runner URL is public, so we
+// put a single HTTP Basic Auth gate in front of the whole app (static SPA +
+// /api/*). Credentials come from env:
+//   STUDYLENS_AUTH_USER / STUDYLENS_AUTH_PASS
+// If STUDYLENS_AUTH_PASS is unset we fail closed (refuse all requests) rather
+// than exposing the notes and the LLM key to the open internet.
+const express = require('express');
+const crypto = require('crypto');
+const studylens = require('studylens/server/index.js'); // exported Express app
+
+const USER = process.env.STUDYLENS_AUTH_USER || 'studylens';
+const PASS = process.env.STUDYLENS_AUTH_PASS || '';
+
+// Timing-safe compare to avoid leaking length/prefix via response timing.
+function safeEqual(a, b) {
+  const ba = Buffer.from(String(a));
+  const bb = Buffer.from(String(b));
+  if (ba.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ba, bb);
+}
+
+const gate = express();
+
+gate.use((req, res, next) => {
+  if (!PASS) {
+    return res.status(503).send('Server not configured: STUDYLENS_AUTH_PASS missing.');
+  }
+  const header = req.headers['authorization'] || '';
+  const [scheme, encoded] = header.split(' ');
+  if (scheme === 'Basic' && encoded) {
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+    const idx = decoded.indexOf(':');
+    const u = decoded.slice(0, idx);
+    const p = decoded.slice(idx + 1);
+    if (safeEqual(u, USER) && safeEqual(p, PASS)) return next();
+  }
+  res.set('WWW-Authenticate', 'Basic realm="StudyLens", charset="UTF-8"');
+  return res.status(401).send('Authentication required.');
+});
+
+// Everything past the gate is handled by the real StudyLens app.
+gate.use(studylens);
+
+const PORT = process.env.PORT || 3000;
+gate.listen(PORT, () => console.log(`StudyLens (auth-gated) running on :${PORT}`));

--- a/devops/studylens-fargate-bedrock/terraform/main.tf
+++ b/devops/studylens-fargate-bedrock/terraform/main.tf
@@ -1,0 +1,320 @@
+data "aws_caller_identity" "current" {}
+
+# ---------------------------------------------------------------------------
+# Network: default VPC (or a supplied one) and one subnet per supported AZ.
+# ---------------------------------------------------------------------------
+data "aws_vpc" "selected" {
+  id      = var.vpc_id != "" ? var.vpc_id : null
+  default = var.vpc_id == "" ? true : null
+}
+
+data "aws_subnets" "in_vpc" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
+  filter {
+    name   = "availability-zone"
+    values = var.supported_azs
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Security groups
+# ---------------------------------------------------------------------------
+# Task SG: NFS to itself (EFS) + app port 3000 from the ALB.
+resource "aws_security_group" "task" {
+  name        = "${var.name}-efs"
+  description = "StudyLens task: EFS NFS (self) + app port from ALB"
+  vpc_id      = data.aws_vpc.selected.id
+}
+
+resource "aws_security_group_rule" "task_nfs_self" {
+  type              = "ingress"
+  security_group_id = aws_security_group.task.id
+  from_port         = 2049
+  to_port           = 2049
+  protocol          = "tcp"
+  self              = true
+}
+
+resource "aws_security_group_rule" "task_app_from_alb" {
+  type                     = "ingress"
+  security_group_id        = aws_security_group.task.id
+  from_port                = 3000
+  to_port                  = 3000
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.alb.id
+}
+
+resource "aws_security_group_rule" "task_egress" {
+  type              = "egress"
+  security_group_id = aws_security_group.task.id
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+# ALB SG: HTTP 80 from the internet (CloudFront origin fetch).
+resource "aws_security_group" "alb" {
+  name        = "${var.name}-alb"
+  description = "StudyLens ALB: HTTP 80 in"
+  vpc_id      = data.aws_vpc.selected.id
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# ---------------------------------------------------------------------------
+# EFS: persistent /data for StudyLens JSON knowledge base
+# ---------------------------------------------------------------------------
+resource "aws_efs_file_system" "data" {
+  creation_token = "${var.name}-data"
+  encrypted      = true
+  tags           = { Name = var.name }
+}
+
+resource "aws_efs_mount_target" "mt" {
+  for_each        = toset(data.aws_subnets.in_vpc.ids)
+  file_system_id  = aws_efs_file_system.data.id
+  subnet_id       = each.value
+  security_groups = [aws_security_group.task.id]
+}
+
+resource "aws_efs_access_point" "ap" {
+  file_system_id = aws_efs_file_system.data.id
+  posix_user {
+    uid = 1000
+    gid = 1000
+  }
+  root_directory {
+    path = "/studylens"
+    creation_info {
+      owner_uid   = 1000
+      owner_gid   = 1000
+      permissions = "755"
+    }
+  }
+  tags = { Name = var.name }
+}
+
+# ---------------------------------------------------------------------------
+# IAM: task execution role (ECR pull + logs) and task role (Bedrock)
+# ---------------------------------------------------------------------------
+data "aws_iam_policy_document" "ecs_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "exec" {
+  name               = "${var.name}-ecs-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+}
+
+resource "aws_iam_role_policy_attachment" "exec_managed" {
+  role       = aws_iam_role.exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name}-ecs-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+}
+
+data "aws_iam_policy_document" "bedrock" {
+  statement {
+    actions = ["bedrock:InvokeModel", "bedrock:Converse", "bedrock:ConverseStream"]
+    resources = [
+      "arn:aws:bedrock:${var.region}:${data.aws_caller_identity.current.account_id}:inference-profile/${var.bedrock_inference_profile_id}",
+      "arn:aws:bedrock:*::foundation-model/*",
+      "arn:aws:bedrock:${var.region}:${data.aws_caller_identity.current.account_id}:inference-profile/*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "task_bedrock" {
+  name   = "${var.name}-bedrock"
+  role   = aws_iam_role.task.id
+  policy = data.aws_iam_policy_document.bedrock.json
+}
+
+# ---------------------------------------------------------------------------
+# Logs + ECS cluster + task definition + service
+# ---------------------------------------------------------------------------
+resource "aws_cloudwatch_log_group" "app" {
+  name              = "/ecs/${var.name}"
+  retention_in_days = 30
+}
+
+resource "aws_ecs_cluster" "this" {
+  name = var.name
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = var.name
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = aws_iam_role.exec.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  volume {
+    name = "data"
+    efs_volume_configuration {
+      file_system_id     = aws_efs_file_system.data.id
+      transit_encryption = "ENABLED"
+      authorization_config {
+        access_point_id = aws_efs_access_point.ap.id
+        iam             = "DISABLED"
+      }
+    }
+  }
+
+  container_definitions = jsonencode([{
+    name         = var.name
+    image        = var.image_uri
+    essential    = true
+    portMappings = [{ containerPort = 3000, protocol = "tcp" }]
+    mountPoints  = [{ sourceVolume = "data", containerPath = "/data" }]
+    environment = [
+      { name = "STUDYLENS_AUTH_USER", value = var.basic_auth_user },
+      { name = "STUDYLENS_AUTH_PASS", value = var.basic_auth_pass },
+      { name = "BEDROCK_REGION", value = var.region },
+      { name = "BEDROCK_MODEL_ID", value = var.bedrock_inference_profile_id },
+      { name = "ADAPTER_PORT", value = "8787" },
+    ]
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.app.name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = var.name
+      }
+    }
+  }])
+}
+
+resource "aws_ecs_service" "this" {
+  name            = var.name
+  cluster         = aws_ecs_cluster.this.id
+  task_definition = aws_ecs_task_definition.this.arn
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = data.aws_subnets.in_vpc.ids
+    security_groups  = [aws_security_group.task.id]
+    assign_public_ip = true # default VPC has an IGW, no NAT
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.this.arn
+    container_name   = var.name
+    container_port   = 3000
+  }
+
+  health_check_grace_period_seconds = 120
+  depends_on                        = [aws_lb_listener.http, aws_efs_mount_target.mt]
+}
+
+# ---------------------------------------------------------------------------
+# ALB (internet-facing, HTTP:80) — CloudFront fronts it with HTTPS
+# ---------------------------------------------------------------------------
+resource "aws_lb" "this" {
+  name               = "${var.name}-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [aws_security_group.alb.id]
+  subnets            = data.aws_subnets.in_vpc.ids
+}
+
+resource "aws_lb_target_group" "this" {
+  name        = "${var.name}-tg"
+  port        = 3000
+  protocol    = "HTTP"
+  vpc_id      = data.aws_vpc.selected.id
+  target_type = "ip"
+  health_check {
+    path                = "/"
+    matcher             = "200,401" # Basic-Auth returns 401 unauthenticated
+    interval            = 15
+    healthy_threshold   = 2
+    unhealthy_threshold = 5
+  }
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}
+
+# ---------------------------------------------------------------------------
+# CloudFront: free trusted *.cloudfront.net HTTPS in front of the HTTP ALB.
+# Managed policies: CachingDisabled + AllViewerExceptHostHeader.
+# ---------------------------------------------------------------------------
+data "aws_cloudfront_cache_policy" "disabled" {
+  name = "Managed-CachingDisabled"
+}
+
+data "aws_cloudfront_origin_request_policy" "all_viewer_except_host" {
+  name = "Managed-AllViewerExceptHostHeader"
+}
+
+resource "aws_cloudfront_distribution" "this" {
+  enabled = true
+  comment = var.name
+
+  origin {
+    domain_name = aws_lb.this.dns_name
+    origin_id   = "alb"
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    target_origin_id         = "alb"
+    viewer_protocol_policy   = "redirect-to-https"
+    allowed_methods          = ["GET", "HEAD", "OPTIONS", "PUT", "POST", "PATCH", "DELETE"]
+    cached_methods           = ["GET", "HEAD"]
+    cache_policy_id          = data.aws_cloudfront_cache_policy.disabled.id
+    origin_request_policy_id = data.aws_cloudfront_origin_request_policy.all_viewer_except_host.id
+    compress                 = true
+  }
+
+  price_class = "PriceClass_100"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/devops/studylens-fargate-bedrock/terraform/outputs.tf
+++ b/devops/studylens-fargate-bedrock/terraform/outputs.tf
@@ -1,0 +1,20 @@
+output "public_url" {
+  description = "The HTTPS URL to open on phone/iPad (add to Home Screen)."
+  value       = "https://${aws_cloudfront_distribution.this.domain_name}"
+}
+
+output "cloudfront_domain" {
+  value = aws_cloudfront_distribution.this.domain_name
+}
+
+output "alb_dns_name" {
+  value = aws_lb.this.dns_name
+}
+
+output "efs_id" {
+  value = aws_efs_file_system.data.id
+}
+
+output "ecs_cluster" {
+  value = aws_ecs_cluster.this.name
+}

--- a/devops/studylens-fargate-bedrock/terraform/terraform.tfvars.example
+++ b/devops/studylens-fargate-bedrock/terraform/terraform.tfvars.example
@@ -1,0 +1,7 @@
+# Copy to terraform.tfvars (gitignored) and fill in.
+region                       = "us-east-1"
+image_uri                    = "<ACCOUNT_ID>.dkr.ecr.us-east-1.amazonaws.com/studylens:latest"
+bedrock_inference_profile_id = "us.openai.gpt-5.6-luna"
+basic_auth_user              = "liang"
+# Prefer: export TF_VAR_basic_auth_pass=... (do not commit the real password)
+basic_auth_pass              = "change-me"

--- a/devops/studylens-fargate-bedrock/terraform/variables.tf
+++ b/devops/studylens-fargate-bedrock/terraform/variables.tf
@@ -1,0 +1,56 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "name" {
+  description = "Base name for all StudyLens resources"
+  type        = string
+  default     = "studylens"
+}
+
+variable "image_uri" {
+  description = "ECR image URI (with tag) built from ../app. e.g. <acct>.dkr.ecr.us-east-1.amazonaws.com/studylens:latest"
+  type        = string
+}
+
+variable "bedrock_inference_profile_id" {
+  description = "Bedrock inference profile id the in-container adapter calls"
+  type        = string
+  default     = "us.openai.gpt-5.6-luna"
+}
+
+variable "basic_auth_user" {
+  description = "HTTP Basic-Auth username enforced by the container's auth wrapper"
+  type        = string
+  default     = "liang"
+}
+
+variable "basic_auth_pass" {
+  description = "HTTP Basic-Auth password. Provide via TF_VAR_basic_auth_pass or a tfvars file kept out of git."
+  type        = string
+  sensitive   = true
+}
+
+variable "vpc_id" {
+  description = "VPC to deploy into. Empty string = use the account's default VPC."
+  type        = string
+  default     = ""
+}
+
+variable "supported_azs" {
+  description = "AZs allowed for the Fargate task + ALB + EFS mount targets (this account rejects use1-az3/az5/az6 for these services)."
+  type        = list(string)
+  default     = ["us-east-1a", "us-east-1c", "us-east-1d"]
+}
+
+variable "cpu" {
+  type    = string
+  default = "256"
+}
+
+variable "memory" {
+  type    = string
+  default = "512"
+}

--- a/devops/studylens-fargate-bedrock/terraform/versions.tf
+++ b/devops/studylens-fargate-bedrock/terraform/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.40"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}


### PR DESCRIPTION
Adds `devops/studylens-fargate-bedrock/` documenting and codifying the StudyLens AWS deployment.

## What's included
- **README.md** — architecture (mermaid), why App Runner was rejected (no EFS + retiring), why CloudFront (free HTTPS, no domain), deploy process (CodeBuild image build + Terraform infra), operations, cost (~$22/mo), teardown.
- **terraform/** — full IaC reproducing the live stack: EFS + access point + mount targets, task/exec IAM roles (Bedrock, keyless), ECS cluster/task-def/service (EFS volume at /data), ALB + target group + HTTP listener, CloudFront (managed CachingDisabled + AllViewerExceptHostHeader). `terraform validate` passes.
- **app/** — container assets: Dockerfile (wraps studylens@0.1.8), server.js (Basic-Auth wrapper), bedrock-openai-adapter.js (OpenAI→Bedrock Converse shim), entrypoint.sh, buildspec.yml.

## Notes
- Pattern is reusable for any stateful, local-filesystem, OpenAI-compatible container.
- No secrets committed: password is a TF variable (`TF_VAR_basic_auth_pass`), tfvars gitignored.
- Live stack was deployed imperatively via boto3; this PR provides the equivalent reproducible Terraform.